### PR TITLE
Added a makefile target for Graviton hosts.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
 .env
 build-ecs.sh
 build.sh
-darwin_release_x64.tar.gz
-linux_release_x64.tar.gz
+built/
+fixtures/
 src/
 target/
+Dockerfile
+Dockerfile.builds

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
-releases
+built
 .env
 *.tar
 *.tar.gz

--- a/Cross.toml
+++ b/Cross.toml
@@ -4,3 +4,6 @@ image = "rust:latest"
 
 [target.x86_64-unknown-linux-musl]
 image = "clux/muslrust"
+
+[target.aarch64-unknown-linux-gnu]
+image = "rust:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ ENV RUST_LOG=$log_level
 
 RUN apk add --no-cache bash libc6-compat
 WORKDIR /loudbot
-ADD ./releases/unknown-linux-musl.tar.gz .
+ADD ./built/loudbot-unknown-linux-musl.tgz .
 
 CMD ["/loudbot/LOUDBOT"]

--- a/Dockerfile.builds
+++ b/Dockerfile.builds
@@ -1,0 +1,7 @@
+FROM rust:latest
+LABEL maintainer="ceejceej@gmail.com"
+
+RUN cargo search cross
+RUN rustup target install x86_64-unknown-linux-gnu && rustup target install x86_64-unknown-linux-musl
+
+CMD ["bin/bash"]

--- a/justfile
+++ b/justfile
@@ -1,0 +1,7 @@
+set dotenv-load := false
+
+buildbox:
+    docker build -t loudcross - < Dockerfile.builds
+
+check-box:
+    docker run -v $(PWD):/src -w /src --rm -it loudcross /bin/bash


### PR DESCRIPTION
The makefile is also a lot nicer now.  Pity about the arm vs x86 miseries.
tl;dr: run the graviton & both mac builds on an M1; run the x86 linux builds
on an x86 mac until I figure out how to docker cross-architecture better.